### PR TITLE
Ignore flake8 E128

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
   - python manage.py collectstatic --noinput
 
 script:
-  - flake8 .
+  - flake8 . --ignore=E128
   - coverage run --source='main' manage.py test --verbosity 2
 
 after_success:


### PR DESCRIPTION
Can't get around with E128 always. Adding to ignore this in Travis; still should be followed wherever possible.