### PR TITLE
Move Journey from header to footer

### DIFF
--- a/oshc/main/templates/base.html
+++ b/oshc/main/templates/base.html
@@ -34,7 +34,6 @@
           </li>
           <li><a href="https://github.com/OpenSourceHelpCommunity" target="_blank">Resources</a></li>
           <li><a href="{% url 'contests' %}" target="_blank">Contests</a></li>
-          <li><a href="{% url 'journey' %}" target="_blank">Journey</a></li>
           <li><a href="https://opensourcehelp.herokuapp.com/" target="_blank">Join Us!</a></li>
           {% if user.is_authenticated %}
           <li><a href="#!">Hey {{ user.username }}!</a></li>
@@ -69,6 +68,9 @@
 								<li>
 									<a href="https://github.com/OpenSourceHelpCommunity" target="_blank"><i class="fa fa-github" aria-hidden="true"></i></a>
 								</li>
+		      						<li>
+									<a href="{% url 'journey' %}" target="_blank"><i class="fa fa-users" aria-hidden="true"></i></a>
+		      						</li>
 								<li>
 									<a href="https://www.youtube.com/channel/UC1_IAby-9me3iICtxuiDL5Q" target="_blank"><i class="fa fa-youtube-play" aria-hidden="true"></i></a>
 								</li>


### PR DESCRIPTION
<!-- Thank you for submitting this PR. You are awesome!
-->

**Checklist**

- [X] My branch is up-to-date with the upstream `predev` branch.
- [X] I have added necessary documentation (if appropriate).

**Which issue does this PR fix?**: 
fixes #212 
This pull request moves the journey link from the header to the footer of the site.  It also replaces the string "Journey" with the fa-users icon from fontawesome.io

**Why do we need this PR?**:

Athstetic

**Testing instructions:**

N/A 

**TODOs (if any)**:

**A picture of a cute animal (not mandatory but encouraged)**:
![cute-baby-animals-10](https://user-images.githubusercontent.com/34851708/34451557-19074dfe-ecef-11e7-89ea-692eff5a7c7b.jpg)

