### PR TITLE
Fix for #210: Removed target attribute from some links.

### DIFF
--- a/oshc/main/templates/base.html
+++ b/oshc/main/templates/base.html
@@ -29,11 +29,11 @@
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">Sessions <span class="caret"></span></a>
             <ul class="dropdown-menu" role="menu">
               <li><a href="https://www.youtube.com/channel/UC1_IAby-9me3iICtxuiDL5Q/videos" target="_blank">View Session</a></li>
-              <li><a href="{% url 'request_session' %}" target="_blank">Request a Session</a></li>
+              <li><a href="{% url 'request_session' %}">Request a Session</a></li>
             </ul>
           </li>
           <li><a href="https://github.com/OpenSourceHelpCommunity" target="_blank">Resources</a></li>
-          <li><a href="{% url 'contests' %}" target="_blank">Contests</a></li>
+          <li><a href="{% url 'contests' %}">Contests</a></li>
           <li><a href="https://opensourcehelp.herokuapp.com/" target="_blank">Join Us!</a></li>
           {% if user.is_authenticated %}
           <li><a href="#!">Hey {{ user.username }}!</a></li>
@@ -69,7 +69,7 @@
 									<a href="https://github.com/OpenSourceHelpCommunity" target="_blank"><i class="fa fa-github" aria-hidden="true"></i></a>
 								</li>
 		      						<li>
-									<a href="{% url 'journey' %}" target="_blank"><i class="fa fa-users" aria-hidden="true"></i></a>
+									<a href="{% url 'journey' %}"><i class="fa fa-users" aria-hidden="true"></i></a>
 		      						</li>
 								<li>
 									<a href="https://www.youtube.com/channel/UC1_IAby-9me3iICtxuiDL5Q" target="_blank"><i class="fa fa-youtube-play" aria-hidden="true"></i></a>


### PR DESCRIPTION
<!-- Thank you for submitting this PR. You are awesome!
-->

**Checklist**

- [x] My branch is up-to-date with the upstream `predev` branch.
- [x] I have added necessary documentation (if appropriate).

**Which issue does this PR fix?**: 
Fixes issue #210 (links undesirably opening in new tab).

This PR removes the target attribute entirely for each anchor tag mentioned in issue 210 inside /oshc/main/templates/base.html.  To allow for consistency, I opted to completely remove the target attribute so that it matches other in-tab-opening links on the same page.  This removal has been applied to the following links:

- Request a Session (under the Session drop-down of the nav-bar)
- Contests (on the nav-bar)
- Journey (in the footer, the flower-box emblem)

**Why do we need this PR?**:
UI/UX alteration to provide for favorable user interaction (altered links don't open in new tab when they don't need to).

**Testing instructions:**
I have taken the following steps, and am leaving them unchecked below for you to use:

- [ ] Create a virtual environment (and activate it)
- [ ] Clone the forked repository.
- [ ] Update to predev branch if you haven't [I don't know whether git saved that or not] (```git fetch https://github.com/OpenSourceHelpCommunity/OpenSourceHelpCommunity.github.io/predev```)
- [ ] Install pre-commit
- [ ] collectstatic (```python manage.py collectstatic```)
- [ ] Run development server (```python manage.py runserver```)
- [ ] Click on altered links in order to verify desired functionality.

**TODOs (if any)**:
None

**A picture of a cute animal (not mandatory but encouraged)**:
Old but good:
![pzhjedp](https://user-images.githubusercontent.com/9625968/34700531-76292ec0-f498-11e7-8050-eea76c3ccd6f.jpg)


  
  